### PR TITLE
Add new metrics tracking in manipulator (size and extension)

### DIFF
--- a/pkg/metrics/utils.go
+++ b/pkg/metrics/utils.go
@@ -1,0 +1,19 @@
+package metrics
+
+// GetImageSizeCluster takes in byte array and return the size cluster for tracking purpose
+func GetImageSizeCluster(imageData []byte) string {
+	switch sz := len(imageData); {
+	case sz <= 128*1024:
+		return "<=128KB"
+	case sz <= 256*1024:
+		return "<=256KB"
+	case sz <= 512*1024:
+		return "<=512KB"
+	case sz <= 1024*1024:
+		return "<=1MB"
+	case sz <= 2048*1024:
+		return "<=2MB"
+	default:
+		return ">2MB"
+	}
+}

--- a/pkg/metrics/utils_test.go
+++ b/pkg/metrics/utils_test.go
@@ -1,0 +1,15 @@
+package metrics
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestGetImageSizeCluster(t *testing.T) {
+	assert.Equal(t, "<=128KB", GetImageSizeCluster(make([]byte, 128*1024)), "<=500KB")
+	assert.Equal(t, "<=256KB", GetImageSizeCluster(make([]byte, 256*1024)), "<=500KB")
+	assert.Equal(t, "<=512KB", GetImageSizeCluster(make([]byte, 512*1024)), "<=500KB")
+	assert.Equal(t, "<=1MB", GetImageSizeCluster(make([]byte, 1024*1024)), "<=500KB")
+	assert.Equal(t, "<=2MB", GetImageSizeCluster(make([]byte, 2048*1024)), "<=500KB")
+	assert.Equal(t, ">2MB", GetImageSizeCluster(make([]byte, 2049*1024)), "<=500KB")
+}

--- a/pkg/service/manipulator_test.go
+++ b/pkg/service/manipulator_test.go
@@ -1,11 +1,14 @@
 package service
 
 import (
+	"fmt"
 	"github.com/gojek/darkroom/pkg/processor"
 	"github.com/gojek/darkroom/pkg/processor/native"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"io/ioutil"
 	"testing"
+	"time"
 )
 
 func TestNewManipulator(t *testing.T) {
@@ -75,6 +78,23 @@ func TestCleanInt(t *testing.T) {
 	assert.Equal(t, 0, CleanInt("0"))
 	assert.Equal(t, 0, CleanInt("garbage"))
 	assert.Equal(t, 0, CleanInt("-234"))
+}
+
+func Test_trackDuration(t *testing.T) {
+	imageData, err := ioutil.ReadFile("../processor/native/_testdata/test.png")
+	if err != nil {
+		panic(err)
+	}
+
+	updateOption := trackDuration(cropDurationKey, time.Now(), ProcessSpec{
+		ImageData: imageData,
+	})
+	assert.Equal(t, fmt.Sprintf("%s.%s.%s", cropDurationKey, "<=128KB", "png"), updateOption.Name)
+
+	updateOption = trackDuration(cropDurationKey, time.Now(), ProcessSpec{
+		ImageData: make([]byte, 10, 10),
+	})
+	assert.Equal(t, fmt.Sprintf("%s.%s.%s", cropDurationKey, "<=128KB", "octet-stream"), updateOption.Name)
 }
 
 type mockProcessor struct {


### PR DESCRIPTION
This new metrics will help us to track to compare the processing time of each file size cluster and extension