### PR TITLE
[BREAKING] Change Processor interface to img instead of []byte to improve performance

### DIFF
--- a/pkg/processor/interface.go
+++ b/pkg/processor/interface.go
@@ -1,14 +1,20 @@
 package processor
 
+import "image"
+
 // Processor interface for performing operations on image bytes
 type Processor interface {
-	// Crop takes an input byte array, width, height and a CropPoint and returns the cropped image bytes or error
-	Crop(input []byte, width, height int, point CropPoint) ([]byte, error)
-	// Resize takes an input byte array, width and height and returns the re-sized image bytes or error
-	Resize(input []byte, width, height int) ([]byte, error)
+	// Crop takes an image.Image, width, height and a CropPoint and returns the cropped image
+	Crop(image image.Image, width, height int, point CropPoint) image.Image
+	// Resize takes an image.Image, width and height and returns the re-sized image
+	Resize(image image.Image, width, height int) image.Image
+	// GrayScale takes an input byte array and returns the grayscaled byte array or error
+	GrayScale(image image.Image) image.Image
 	// Watermark takes an input byte array, overlay byte array and opacity value
 	// and returns the watermarked image bytes or error
 	Watermark(base []byte, overlay []byte, opacity uint8) ([]byte, error)
-	// GrayScale takes an input byte array and returns the grayscaled byte array or error
-	GrayScale(input []byte) ([]byte, error)
+	// Decode takes a byte array and returns the image, extension, and error
+	Decode(data []byte) (image.Image, string, error)
+	// Encode takes an image and extension and return the encoded byte array or error
+	Encode(img image.Image, format string) ([]byte, error)
 }

--- a/pkg/processor/native/processor.go
+++ b/pkg/processor/native/processor.go
@@ -103,27 +103,22 @@ func (bp *BildProcessor) GrayScale(input []byte) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	img = grayScale(img)
-
-	return bp.encode(img, f)
-}
-
-func grayScale(img image.Image) image.Image {
 	src := clone.AsRGBA(img)
 	bounds := src.Bounds()
 	if bounds.Empty() {
-		return &image.RGBA{}
-	}
-	parallel.Line(bounds.Dy(), func(start, end int) {
-		for y := start; y < end; y++ {
-			for x := 0; x < bounds.Dx(); x++ {
-				srcPix := src.At(x, y).(color.RGBA)
-				g := color.GrayModel.Convert(srcPix).(color.Gray).Y
-				src.Set(x, y, color.RGBA{R: g, G: g, B: g, A: srcPix.A})
+		src = &image.RGBA{}
+	} else {
+		parallel.Line(bounds.Dy(), func(start, end int) {
+			for y := start; y < end; y++ {
+				for x := 0; x < bounds.Dx(); x++ {
+					srcPix := src.At(x, y).(color.RGBA)
+					g := color.GrayModel.Convert(srcPix).(color.Gray).Y
+					src.Set(x, y, color.RGBA{R: g, G: g, B: g, A: srcPix.A})
+				}
 			}
-		}
-	})
-	return src
+		})
+	}
+	return bp.encode(src, f)
 }
 
 func (bp *BildProcessor) decode(data []byte) (image.Image, string, error) {

--- a/pkg/processor/native/processor.go
+++ b/pkg/processor/native/processor.go
@@ -29,12 +29,7 @@ type BildProcessor struct {
 }
 
 // Crop takes an input byte array, width, height and a CropPoint and returns the cropped image bytes or error
-func (bp *BildProcessor) Crop(input []byte, width, height int, point processor.CropPoint) ([]byte, error) {
-	img, f, err := bp.decode(input)
-	if err != nil {
-		return nil, err
-	}
-
+func (bp *BildProcessor) Crop(img image.Image, width, height int, point processor.CropPoint) image.Image {
 	w, h := getResizeWidthAndHeightForCrop(width, height, img.Bounds().Dx(), img.Bounds().Dy())
 
 	img = transform.Resize(img, w, h, transform.Linear)
@@ -42,15 +37,11 @@ func (bp *BildProcessor) Crop(input []byte, width, height int, point processor.C
 	rect := image.Rect(x0, y0, width+x0, height+y0)
 	img = (clone.AsRGBA(img)).SubImage(rect)
 
-	return bp.encode(img, f)
+	return img
 }
 
 // Resize takes an input byte array, width and height and returns the re-sized image bytes or error
-func (bp *BildProcessor) Resize(input []byte, width, height int) ([]byte, error) {
-	img, f, err := bp.decode(input)
-	if err != nil {
-		return nil, err
-	}
+func (bp *BildProcessor) Resize(img image.Image, width, height int) image.Image {
 
 	initW := img.Bounds().Dx()
 	initH := img.Bounds().Dy()
@@ -60,17 +51,17 @@ func (bp *BildProcessor) Resize(input []byte, width, height int) ([]byte, error)
 		img = transform.Resize(img, w, h, transform.Linear)
 	}
 
-	return bp.encode(img, f)
+	return img
 }
 
 // Watermark takes an input byte array, overlay byte array and opacity value
 // and returns the watermarked image bytes or error
 func (bp *BildProcessor) Watermark(base []byte, overlay []byte, opacity uint8) ([]byte, error) {
-	baseImg, f, err := bp.decode(base)
+	baseImg, f, err := bp.Decode(base)
 	if err != nil {
 		return nil, err
 	}
-	overlayImg, _, err := bp.decode(overlay)
+	overlayImg, _, err := bp.Decode(overlay)
 	if err != nil {
 		return nil, err
 	}
@@ -94,15 +85,11 @@ func (bp *BildProcessor) Watermark(base []byte, overlay []byte, opacity uint8) (
 	draw.DrawMask(baseImg.(draw.Image), overlayImg.Bounds().Add(offset), overlayImg, image.ZP, mask, image.ZP, draw.Over)
 	metrics.Update(metrics.UpdateOption{Name: watermarkDurationKey, Type: metrics.Duration, Duration: time.Since(t)})
 
-	return bp.encode(baseImg, f)
+	return bp.Encode(baseImg, f)
 }
 
 // GrayScale takes an input byte array and returns the grayscaled byte array or error
-func (bp *BildProcessor) GrayScale(input []byte) ([]byte, error) {
-	img, f, err := bp.decode(input)
-	if err != nil {
-		return nil, err
-	}
+func (bp *BildProcessor) GrayScale(img image.Image) image.Image {
 	src := clone.AsRGBA(img)
 	bounds := src.Bounds()
 	if bounds.Empty() {
@@ -118,10 +105,10 @@ func (bp *BildProcessor) GrayScale(input []byte) ([]byte, error) {
 			}
 		})
 	}
-	return bp.encode(src, f)
+	return src
 }
 
-func (bp *BildProcessor) decode(data []byte) (image.Image, string, error) {
+func (bp *BildProcessor) Decode(data []byte) (image.Image, string, error) {
 	t := time.Now()
 	img, f, err := image.Decode(bytes.NewReader(data))
 	if err == nil {
@@ -130,7 +117,7 @@ func (bp *BildProcessor) decode(data []byte) (image.Image, string, error) {
 	return img, f, err
 }
 
-func (bp *BildProcessor) encode(img image.Image, format string) ([]byte, error) {
+func (bp *BildProcessor) Encode(img image.Image, format string) ([]byte, error) {
 	t := time.Now()
 	if format == pngType && isOpaque(img) {
 		format = jpgType

--- a/pkg/processor/native/processor.go
+++ b/pkg/processor/native/processor.go
@@ -114,17 +114,16 @@ func grayScale(img image.Image) image.Image {
 	if bounds.Empty() {
 		return &image.RGBA{}
 	}
-	dst := image.NewRGBA(bounds)
 	parallel.Line(bounds.Dy(), func(start, end int) {
 		for y := start; y < end; y++ {
 			for x := 0; x < bounds.Dx(); x++ {
 				srcPix := src.At(x, y).(color.RGBA)
 				g := color.GrayModel.Convert(srcPix).(color.Gray).Y
-				dst.Set(x, y, color.RGBA{R: g, G: g, B: g, A: srcPix.A})
+				src.Set(x, y, color.RGBA{R: g, G: g, B: g, A: srcPix.A})
 			}
 		}
 	})
-	return dst
+	return src
 }
 
 func (bp *BildProcessor) decode(data []byte) (image.Image, string, error) {

--- a/pkg/processor/native/processor_test.go
+++ b/pkg/processor/native/processor_test.go
@@ -1,7 +1,6 @@
 package native
 
 import (
-	"bytes"
 	"github.com/gojek/darkroom/pkg/processor"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
@@ -13,16 +12,20 @@ import (
 type BildProcessorSuite struct {
 	suite.Suite
 	srcData       []byte
+	srcImage      image.Image
 	watermarkData []byte
 	badData       []byte
+	badImage      image.Image
 	processor     processor.Processor
 }
 
 func (s *BildProcessorSuite) SetupSuite() {
 	s.processor = NewBildProcessor()
 	s.srcData, _ = ioutil.ReadFile("_testdata/test.png")
+	s.srcImage, _, _ = s.processor.Decode(s.srcData)
 	s.watermarkData, _ = ioutil.ReadFile("_testdata/overlay.png")
 	s.badData = []byte("badImage.ext")
+
 }
 
 func TestNewBildProcessor(t *testing.T) {
@@ -30,31 +33,27 @@ func TestNewBildProcessor(t *testing.T) {
 }
 
 func (s *BildProcessorSuite) TestBildProcessor_Resize() {
-	output, err := s.processor.Resize(s.srcData, 500, 500)
+	out := s.processor.Resize(s.srcImage, 500, 500)
 
-	assert.NotNil(s.T(), output)
-	assert.Nil(s.T(), err)
-
-	img, _, _ := image.Decode(bytes.NewReader(output))
-	assert.Equal(s.T(), 500, img.Bounds().Dx())
-	assert.Equal(s.T(), 375, img.Bounds().Dy())
+	assert.NotNil(s.T(), out)
+	assert.Equal(s.T(), 500, out.Bounds().Dx())
+	assert.Equal(s.T(), 375, out.Bounds().Dy())
 }
 
 func (s *BildProcessorSuite) TestBildProcessor_Crop() {
-	output, err := s.processor.Crop(s.srcData, 500, 500, processor.CropCenter)
+	out := s.processor.Crop(s.srcImage, 500, 500, processor.CropCenter)
 
-	assert.NotNil(s.T(), output)
-	assert.Nil(s.T(), err)
+	assert.NotNil(s.T(), out)
 
-	img, _, _ := image.Decode(bytes.NewReader(output))
-	assert.Equal(s.T(), 500, img.Bounds().Dx())
-	assert.Equal(s.T(), 500, img.Bounds().Dy())
+	assert.Equal(s.T(), 500, out.Bounds().Dx())
+	assert.Equal(s.T(), 500, out.Bounds().Dy())
 }
 
 func (s *BildProcessorSuite) TestBildProcessor_Grayscale() {
 	var actual, expected []byte
 	var err error
-	actual, err = s.processor.GrayScale(s.srcData)
+	out := s.processor.GrayScale(s.srcImage)
+	actual, err = s.processor.Encode(out, "png")
 	assert.NotNil(s.T(), actual)
 	assert.Nil(s.T(), err)
 
@@ -75,19 +74,7 @@ func (s *BildProcessorSuite) TestBildProcessor_Watermark() {
 }
 
 func (s *BildProcessorSuite) TestBildProcessorWithBadInput() {
-	output, err := s.processor.Crop(s.badData, 0, 0, processor.CropCenter)
-	assert.NotNil(s.T(), err)
-	assert.Nil(s.T(), output)
-
-	output, err = s.processor.Resize(s.badData, 0, 0)
-	assert.NotNil(s.T(), err)
-	assert.Nil(s.T(), output)
-
-	output, err = s.processor.GrayScale(s.badData)
-	assert.NotNil(s.T(), err)
-	assert.Nil(s.T(), output)
-
-	output, err = s.processor.Watermark(s.badData, s.watermarkData, 255)
+	output, err := s.processor.Watermark(s.badData, s.watermarkData, 255)
 	assert.NotNil(s.T(), err)
 	assert.Nil(s.T(), output)
 

--- a/pkg/service/manipulator.go
+++ b/pkg/service/manipulator.go
@@ -47,29 +47,31 @@ type ProcessSpec struct {
 // This manipulator uses bild to do the actual image manipulations
 func (m *manipulator) Process(spec ProcessSpec) ([]byte, error) {
 	params := spec.Params
-	data := spec.ImageData
+	//data := spec.ImageData
 	var err error
+	data, f, err := m.processor.Decode(spec.ImageData)
 	if params[fit] == crop {
 		t := time.Now()
-		data, err = m.processor.Crop(data, CleanInt(params[width]), CleanInt(params[height]), GetCropPoint(params[crop]))
+		data = m.processor.Crop(data, CleanInt(params[width]), CleanInt(params[height]), GetCropPoint(params[crop]))
 		if err == nil {
 			trackDuration(cropDurationKey, t, spec)
 		}
 	} else if len(params[fit]) == 0 && (CleanInt(params[width]) != 0 || CleanInt(params[height]) != 0) {
 		t := time.Now()
-		data, err = m.processor.Resize(data, CleanInt(params[width]), CleanInt(params[height]))
+		data = m.processor.Resize(data, CleanInt(params[width]), CleanInt(params[height]))
 		if err == nil {
 			trackDuration(resizeDurationKey, t, spec)
 		}
 	}
 	if params[mono] == blackHexCode {
 		t := time.Now()
-		data, err = m.processor.GrayScale(data)
+		data = m.processor.GrayScale(data)
 		if err == nil {
 			trackDuration(grayScaleDurationKey, t, spec)
 		}
 	}
-	return data, err
+	src, err := m.processor.Encode(data, f)
+	return src, err
 }
 
 // CleanInt takes a string and return an int not greater than 9999


### PR DESCRIPTION
**Changes:**
This PR is a breaking change to the Processor interface.
- Change Processor interface to `image.Image` instead of `[]byte`
- Remove unneccessary cloning in `grayScale` method

**Reason for changes**:
- 15% performance increase on manipulator.Process when given params is more than one operation (resize/crop + grayscaling).

**Profiling details:**
The profiling is done by processing 96 images from Image Manipulation dataset (https://www5.cs.fau.de/research/data/image-manipulation/) which have varying file sizes (they also have >10 MB pictures).
The process being done is cropping to 50% of width and height with right anchor and grayscaling

**Profiling result:**
using `[]byte` interface:

```
Total: 58.286914s
Average: 0.607s
Minimum: 0.024093s
Maximum: 1.910421s
```

using `image.Image` interface:
```
Total time: 49.394539s
Average: 0.515s
Minimum: 0.018555s
Maximum: 0.998278s
```
