### PR TITLE
add GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/cleanup.md
+++ b/.github/ISSUE_TEMPLATE/cleanup.md
@@ -1,0 +1,12 @@
+---
+name: Cleanup 
+about: Pay down technical debt, reduce friction, etc.
+labels: cleanup
+
+---
+
+<!-- Please use this template while filing an issue to highlight technical debt to be paid down, or friction to be reduced -->
+
+##### What should be cleaned up or changed
+
+##### Provide any links for context

--- a/.github/ISSUE_TEMPLATE/enhancement.md
+++ b/.github/ISSUE_TEMPLATE/enhancement.md
@@ -1,0 +1,16 @@
+---
+name: Feature Request
+about: Suggest a/an feature/enhancement to the Darkroom project
+labels: enhancement
+
+---
+
+<!-- Please only use this template for submitting feature/enhancement requests -->
+
+##### What would you like to be added
+<!-- Describe as precisely as possible how this feature/enhancement should work from the user perspective. What should be changed, etc. -->
+
+##### Why is this needed
+
+##### Comments
+<!-- Any additional related comments that might help. Drawings/mockups would be extremely helpful (if required). -->

--- a/.github/ISSUE_TEMPLATE/failing-test.md
+++ b/.github/ISSUE_TEMPLATE/failing-test.md
@@ -1,0 +1,18 @@
+---
+name: Failing Test
+about: Report test failures in Darkroom CI jobs
+labels: failing-test
+
+---
+
+<!-- Please only use this template for submitting reports about failing tests in Darkroom CI jobs -->
+
+**Which jobs are failing**:
+
+**Which test(s) are failing**:
+
+**Since when has it been failing**:
+
+**Reason for failure**:
+
+**Anything else we need to know**:

--- a/.github/ISSUE_TEMPLATE/issue.md
+++ b/.github/ISSUE_TEMPLATE/issue.md
@@ -1,0 +1,30 @@
+---
+name: Bug Report
+about: Report a bug encountered with Darkroom
+labels: bug
+
+---
+
+<!-- Please use this template while reporting a bug and provide as much info as possible. Not doing so may result in your bug not being addressed in a timely manner. Thanks!-->
+
+##### Environment
+<!-- Describe your setup. Versions of Darkroom, Go etc. are needed only from developers. -->
+
+```
+Installation method:
+Darkroom version:
+Operating system:
+Go version ('go version' output):
+```
+
+##### Steps to reproduce
+<!-- Describe all steps needed to reproduce the issue. It is a good place to use numbered list. -->
+
+##### Observed result
+<!-- Describe observed result as precisely as possible. -->
+
+##### Expected result
+<!-- Describe expected result as precisely as possible. -->
+
+##### Comments
+<!-- If you have any comments or more details, put them here. -->


### PR DESCRIPTION
This PR adds support for GitHub [issue templates](https://help.github.com/en/articles/about-issue-and-pull-request-templates)