### PR TITLE
Register statsd collector for hystrix metrics

### DIFF
--- a/pkg/metrics/statsd_collector.go
+++ b/pkg/metrics/statsd_collector.go
@@ -2,10 +2,13 @@ package metrics
 
 import (
 	"fmt"
-	"github.com/cactus/go-statsd-client/statsd"
-	"github.com/gojek/darkroom/pkg/logger"
 	"strings"
 	"time"
+
+	"github.com/afex/hystrix-go/hystrix/metric_collector"
+	"github.com/afex/hystrix-go/plugins"
+	"github.com/cactus/go-statsd-client/statsd"
+	"github.com/gojek/darkroom/pkg/logger"
 )
 
 // https://github.com/etsy/statsd/blob/master/docs/metric_types.md#multi-metric-packets
@@ -53,6 +56,15 @@ func InitializeStatsdCollector(config *StatsdCollectorConfig) error {
 		c = &statsd.NoopClient{}
 	}
 	instance = &statsdClient{client: c, sampleRate: sampleRate}
+	return nil
+}
+
+func RegisterHystrixMetrics(config *StatsdCollectorConfig, prefix string) error {
+	c, _ := plugins.InitializeStatsdCollector(&plugins.StatsdCollectorConfig{
+		StatsdAddr: config.StatsdAddr,
+		Prefix:     prefix,
+	})
+	metricCollector.Registry.Register(c.NewStatsdCollector)
 	return nil
 }
 

--- a/pkg/metrics/statsd_collector.go
+++ b/pkg/metrics/statsd_collector.go
@@ -60,10 +60,14 @@ func InitializeStatsdCollector(config *StatsdCollectorConfig) error {
 }
 
 func RegisterHystrixMetrics(config *StatsdCollectorConfig, prefix string) error {
-	c, _ := plugins.InitializeStatsdCollector(&plugins.StatsdCollectorConfig{
+	c, err := plugins.InitializeStatsdCollector(&plugins.StatsdCollectorConfig{
 		StatsdAddr: config.StatsdAddr,
 		Prefix:     prefix,
 	})
+	if err != nil {
+		logger.Errorf("failed to initialize statsd collector for hystrix metrics with error: %s", err.Error())
+		return err
+	}
 	metricCollector.Registry.Register(c.NewStatsdCollector)
 	return nil
 }

--- a/pkg/metrics/statsd_collector_test.go
+++ b/pkg/metrics/statsd_collector_test.go
@@ -31,6 +31,11 @@ func TestInitializeStatsdCollector(t *testing.T) {
 func TestRegisterHystrixMetrics(t *testing.T) {
 	err := RegisterHystrixMetrics(&StatsdCollectorConfig{}, "prefix")
 	assert.Nil(t, err)
+
+	err = RegisterHystrixMetrics(&StatsdCollectorConfig{
+		StatsdAddr: "foo:bar:foo",
+	}, "prefix")
+	assert.NotNil(t, err)
 }
 
 func TestUpdate(t *testing.T) {

--- a/pkg/metrics/statsd_collector_test.go
+++ b/pkg/metrics/statsd_collector_test.go
@@ -3,11 +3,12 @@ package metrics
 import (
 	"errors"
 	"fmt"
+	"testing"
+	"time"
+
 	"github.com/cactus/go-statsd-client/statsd"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
-	"testing"
-	"time"
 )
 
 func TestInitializeStatsdCollector(t *testing.T) {
@@ -25,6 +26,11 @@ func TestInitializeStatsdCollector(t *testing.T) {
 	err = InitializeStatsdCollector(&StatsdCollectorConfig{})
 	assert.Nil(t, err)
 	assert.Equal(t, float32(1), instance.sampleRate)
+}
+
+func TestRegisterHystrixMetrics(t *testing.T) {
+	err := RegisterHystrixMetrics(&StatsdCollectorConfig{}, "prefix")
+	assert.Nil(t, err)
 }
 
 func TestUpdate(t *testing.T) {


### PR DESCRIPTION
Adding this functionality because currently, we are not able to see hystrix statistics from the adapters we have in darkroom.