### PR TITLE
Add default parameters support

### DIFF
--- a/internal/handler/image.go
+++ b/internal/handler/image.go
@@ -70,7 +70,11 @@ func getParams(values url.Values) *map[string]string {
 	}
 	for v := range values {
 		if len(values.Get(v)) != 0 {
-			params[v] = values.Get(v)
+			if params[v] != "" {
+				params[v] = fmt.Sprintf("%s,%s", params[v], values.Get(v))
+			} else {
+				params[v] = values.Get(v)
+			}
 		}
 	}
 	return &params

--- a/internal/handler/image_test.go
+++ b/internal/handler/image_test.go
@@ -33,6 +33,37 @@ func (s *ImageHandlerTestSuite) SetupTest() {
 	s.deps = &service.Dependencies{Storage: s.storage, Manipulator: s.manipulator}
 }
 
+func TestGetParams(t *testing.T) {
+	cases := []struct {
+		values        map[string][]string
+		defaultParams string
+		expectedRes   *map[string]string
+	}{
+		{
+			values:        map[string][]string{"foo": {"bar"}},
+			defaultParams: "bar=foo",
+			expectedRes:   &map[string]string{"foo": "bar", "bar": "foo"},
+		},
+		{
+			values:        map[string][]string{},
+			defaultParams: "bar=foo",
+			expectedRes:   &map[string]string{"bar": "foo"},
+		},
+		{
+			values:        map[string][]string{"foo": {"bar"}},
+			defaultParams: "foo=foo",
+			expectedRes:   &map[string]string{"foo": "foo,bar"},
+		},
+	}
+	for _, c := range cases {
+		v := config.Viper()
+		v.Set("defaultParams", c.defaultParams)
+		config.Update()
+
+		assert.Equal(t, c.expectedRes, getParams(c.values))
+	}
+}
+
 func (s *ImageHandlerTestSuite) TestImageHandler() {
 	r, _ := http.NewRequest(http.MethodGet, "/image-valid", nil)
 	rr := httptest.NewRecorder()

--- a/internal/handler/image_test.go
+++ b/internal/handler/image_test.go
@@ -33,42 +33,6 @@ func (s *ImageHandlerTestSuite) SetupTest() {
 	s.deps = &service.Dependencies{Storage: s.storage, Manipulator: s.manipulator}
 }
 
-func TestGetParams(t *testing.T) {
-	cases := []struct {
-		values        map[string][]string
-		defaultParams string
-		expectedRes   *map[string]string
-	}{
-		{
-			values:        map[string][]string{"foo": {"bar"}},
-			defaultParams: "bar=foo",
-			expectedRes:   &map[string]string{"foo": "bar", "bar": "foo"},
-		},
-		{
-			values:        map[string][]string{},
-			defaultParams: "bar=foo",
-			expectedRes:   &map[string]string{"bar": "foo"},
-		},
-		{
-			values:        map[string][]string{"foo": {"bar"}},
-			defaultParams: "foo=foo",
-			expectedRes:   &map[string]string{"foo": "foo,bar"},
-		},
-		{
-			values:        map[string][]string{"foo": {"bar"}},
-			defaultParams: "invalid",
-			expectedRes:   &map[string]string{"foo": "bar"},
-		},
-	}
-	for _, c := range cases {
-		v := config.Viper()
-		v.Set("defaultParams", c.defaultParams)
-		config.Update()
-
-		assert.Equal(t, c.expectedRes, getParams(c.values))
-	}
-}
-
 func (s *ImageHandlerTestSuite) TestImageHandler() {
 	r, _ := http.NewRequest(http.MethodGet, "/image-valid", nil)
 	rr := httptest.NewRecorder()

--- a/internal/handler/image_test.go
+++ b/internal/handler/image_test.go
@@ -54,6 +54,11 @@ func TestGetParams(t *testing.T) {
 			defaultParams: "foo=foo",
 			expectedRes:   &map[string]string{"foo": "foo,bar"},
 		},
+		{
+			values:        map[string][]string{"foo": {"bar"}},
+			defaultParams: "invalid",
+			expectedRes:   &map[string]string{"foo": "bar"},
+		},
 	}
 	for _, c := range cases {
 		v := config.Viper()

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"strings"
 	"sync"
 
 	"github.com/afex/hystrix-go/hystrix"
@@ -95,7 +96,7 @@ func ConcurrentOpacityCheckingEnabled() bool {
 	return getConfig().enableConcurrentOpacityChecking
 }
 
-// DefaultParams returns string of default parameters which will be applied to all image request, following the existing contract
-func DefaultParams() string {
-	return getConfig().defaultParams
+// DefaultParams returns []string of default parameters (separated by semicolon) which will be applied to all image request, following the existing contract
+func DefaultParams() []string {
+	return strings.Split(getConfig().defaultParams, ";")
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,9 +1,10 @@
 package config
 
 import (
+	"sync"
+
 	"github.com/afex/hystrix-go/hystrix"
 	"github.com/gojek/darkroom/pkg/storage"
-	"sync"
 )
 
 type config struct {
@@ -13,6 +14,7 @@ type config struct {
 	cacheTime                       int
 	dataSource                      Source
 	enableConcurrentOpacityChecking bool
+	defaultParams                   string
 }
 
 var instance *config
@@ -54,6 +56,7 @@ func newConfig() *config {
 		cacheTime:                       v.GetInt("cache.time"),
 		dataSource:                      s,
 		enableConcurrentOpacityChecking: v.GetBool("enableConcurrentOpacityChecking"),
+		defaultParams:                   v.GetString("defaultParams"),
 	}
 }
 
@@ -90,4 +93,9 @@ func DataSource() *Source {
 // ConcurrentOpacityCheckingEnabled returns true if we want to process image using multiple cores (checking isOpaque)
 func ConcurrentOpacityCheckingEnabled() bool {
 	return getConfig().enableConcurrentOpacityChecking
+}
+
+// DefaultParams returns string of default parameters which will be applied to all image request, following the existing contract
+func DefaultParams() string {
+	return getConfig().defaultParams
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1,11 +1,12 @@
 package config
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
-func TestConfigCases(t *testing.T) {
+func TestConfigCasesWithStringValues(t *testing.T) {
 	v := Viper()
 	cases := []struct {
 		key      string
@@ -14,6 +15,10 @@ func TestConfigCases(t *testing.T) {
 		{
 			key:      "log.level",
 			callFunc: LogLevel,
+		},
+		{
+			key:      "defaultParams",
+			callFunc: DefaultParams,
 		},
 	}
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -16,10 +16,6 @@ func TestConfigCasesWithStringValues(t *testing.T) {
 			key:      "log.level",
 			callFunc: LogLevel,
 		},
-		{
-			key:      "defaultParams",
-			callFunc: DefaultParams,
-		},
 	}
 
 	for _, c := range cases {
@@ -66,4 +62,23 @@ func TestConfigCasesWithIntValues(t *testing.T) {
 	}
 
 	assert.Equal(t, 0, v.GetInt("nonexistingkey"))
+}
+
+func TestConfigCasesWithStringSliceValues(t *testing.T) {
+	v := Viper()
+	v.Set("defaultParams", "auto=compress")
+	Update()
+	cases := []struct {
+		key      string
+		callFunc func() []string
+	}{
+		{
+			key:      "defaultParams",
+			callFunc: DefaultParams,
+		},
+	}
+
+	for _, c := range cases {
+		assert.Equal(t, v.GetStringSlice(c.key), c.callFunc())
+	}
 }

--- a/pkg/service/dependencies.go
+++ b/pkg/service/dependencies.go
@@ -2,6 +2,7 @@
 package service
 
 import (
+	"strings"
 	"time"
 
 	"github.com/gojek/darkroom/pkg/config"
@@ -25,7 +26,7 @@ type Dependencies struct {
 // Currently, it supports only one Manipulator
 func NewDependencies() *Dependencies {
 	s := config.DataSource()
-	deps := &Dependencies{Manipulator: NewManipulator(native.NewBildProcessor(), map[string]string{})}
+	deps := &Dependencies{Manipulator: NewManipulator(native.NewBildProcessor(), getDefaultParams())}
 	if regex.WebFolderMatcher.MatchString(s.Kind) {
 		deps.Storage = NewWebFolderStorage(s.Value.(config.WebFolder), s.HystrixCommand)
 	} else if regex.S3Matcher.MatchString(s.Kind) {
@@ -34,6 +35,17 @@ func NewDependencies() *Dependencies {
 		deps.Storage = NewCloudfrontStorage(s.Value.(config.Cloudfront), s.HystrixCommand)
 	}
 	return deps
+}
+
+func getDefaultParams() map[string]string {
+	params := make(map[string]string)
+	for _, param := range config.DefaultParams() {
+		if strings.Contains(param, "=") {
+			p := strings.Split(param, "=")
+			params[p[0]] = p[1]
+		}
+	}
+	return params
 }
 
 // NewS3Storage create a new s3.Storage struct from the config.S3Bucket and the HystrixCommand

--- a/pkg/service/dependencies.go
+++ b/pkg/service/dependencies.go
@@ -25,7 +25,7 @@ type Dependencies struct {
 // Currently, it supports only one Manipulator
 func NewDependencies() *Dependencies {
 	s := config.DataSource()
-	deps := &Dependencies{Manipulator: NewManipulator(native.NewBildProcessor())}
+	deps := &Dependencies{Manipulator: NewManipulator(native.NewBildProcessor(), []string{})}
 	if regex.WebFolderMatcher.MatchString(s.Kind) {
 		deps.Storage = NewWebFolderStorage(s.Value.(config.WebFolder), s.HystrixCommand)
 	} else if regex.S3Matcher.MatchString(s.Kind) {

--- a/pkg/service/dependencies.go
+++ b/pkg/service/dependencies.go
@@ -25,7 +25,7 @@ type Dependencies struct {
 // Currently, it supports only one Manipulator
 func NewDependencies() *Dependencies {
 	s := config.DataSource()
-	deps := &Dependencies{Manipulator: NewManipulator(native.NewBildProcessor(), []string{})}
+	deps := &Dependencies{Manipulator: NewManipulator(native.NewBildProcessor(), map[string]string{})}
 	if regex.WebFolderMatcher.MatchString(s.Kind) {
 		deps.Storage = NewWebFolderStorage(s.Value.(config.WebFolder), s.HystrixCommand)
 	} else if regex.S3Matcher.MatchString(s.Kind) {

--- a/pkg/service/dependencies_test.go
+++ b/pkg/service/dependencies_test.go
@@ -16,6 +16,33 @@ func TestNewDependencies(t *testing.T) {
 	assert.Nil(t, deps.Storage)
 }
 
+func TestGetDefaultParams(t *testing.T) {
+	cases := []struct {
+		defaultParams string
+		expectedRes   map[string]string
+	}{
+		{
+			defaultParams: "foo=bar",
+			expectedRes:   map[string]string{"foo": "bar"},
+		},
+		{
+			defaultParams: "foo=foo,bar",
+			expectedRes:   map[string]string{"foo": "foo,bar"},
+		},
+		{
+			defaultParams: "invalid",
+			expectedRes:   map[string]string{},
+		},
+	}
+	for _, c := range cases {
+		v := config.Viper()
+		v.Set("defaultParams", c.defaultParams)
+		config.Update()
+
+		assert.Equal(t, c.expectedRes, getDefaultParams())
+	}
+}
+
 func TestNewDependenciesWithWebFolderStorage(t *testing.T) {
 	v := config.Viper()
 	v.Set("source.kind", "WebFolder")

--- a/pkg/service/manipulator.go
+++ b/pkg/service/manipulator.go
@@ -46,7 +46,8 @@ type Manipulator interface {
 }
 
 type manipulator struct {
-	processor processor.Processor
+	processor     processor.Processor
+	defaultParams []string
 }
 
 // Process takes ProcessSpec as an argument and returns []byte, error
@@ -172,6 +173,9 @@ func trackDuration(name string, start time.Time, spec processSpec) *metrics.Upda
 }
 
 // NewManipulator takes in a Processor interface and returns a new Manipulator
-func NewManipulator(processor processor.Processor) Manipulator {
-	return &manipulator{processor: processor}
+func NewManipulator(processor processor.Processor, defaultParams []string) Manipulator {
+	return &manipulator{
+		processor:     processor,
+		defaultParams: defaultParams,
+	}
 }

--- a/pkg/service/manipulator_test.go
+++ b/pkg/service/manipulator_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func TestNewManipulator(t *testing.T) {
-	m := NewManipulator(native.NewBildProcessor())
+	m := NewManipulator(native.NewBildProcessor(), []string{})
 	assert.NotNil(t, m)
 }
 
@@ -23,7 +23,7 @@ func TestNewManipulator(t *testing.T) {
 func TestManipulator_Process_ReturnsImageAsPNGIfCallerDoesNOTSupportWebP(t *testing.T) {
 	// Use real processor to ensure that right encoder is being used
 	p := native.NewBildProcessor()
-	m := NewManipulator(p)
+	m := NewManipulator(p, []string{})
 
 	img, _ := ioutil.ReadFile("../processor/native/_testdata/test.webp")
 	expectedImg, _ := ioutil.ReadFile("../processor/native/_testdata/test_webp_to_png.png")
@@ -41,7 +41,7 @@ func TestManipulator_Process_ReturnsImageAsPNGIfCallerDoesNOTSupportWebP(t *test
 func TestManipulator_Process_ReturnsImageAsWebPIfCallerSupportsWebP(t *testing.T) {
 	// Use real processor to ensure that right encoder is being used
 	p := native.NewBildProcessor()
-	m := NewManipulator(p)
+	m := NewManipulator(p, []string{})
 
 	img, _ := ioutil.ReadFile("../processor/native/_testdata/test.png")
 	expectedImg, _ := ioutil.ReadFile("../processor/native/_testdata/test_png_to_webp.webp")
@@ -58,7 +58,7 @@ func TestManipulator_Process_ReturnsImageAsWebPIfCallerSupportsWebP(t *testing.T
 
 func TestManipulator_Process(t *testing.T) {
 	mp := &mockProcessor{}
-	m := NewManipulator(mp)
+	m := NewManipulator(mp, []string{})
 	params := make(map[string]string)
 
 	input := []byte("inputData")
@@ -71,7 +71,7 @@ func TestManipulator_Process(t *testing.T) {
 
 	// Create new struct for asserting expectations
 	mp = &mockProcessor{}
-	m = NewManipulator(mp)
+	m = NewManipulator(mp, []string{})
 	mp.On("Decode", input).Return(decoded, "png", nil)
 	mp.On("Encode", decoded, "png").Return(input, nil)
 	mp.On("Crop", decoded, 100, 100, processor.CropCenter).Return(decoded, nil)

--- a/pkg/service/manipulator_test.go
+++ b/pkg/service/manipulator_test.go
@@ -8,8 +8,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gojek/darkroom/pkg/config"
-
 	"github.com/gojek/darkroom/pkg/processor"
 	"github.com/gojek/darkroom/pkg/processor/native"
 	"github.com/stretchr/testify/assert"
@@ -147,10 +145,6 @@ func TestGetParams(t *testing.T) {
 		},
 	}
 	for _, c := range cases {
-		v := config.Viper()
-		v.Set("defaultParams", c.defaultParams)
-		config.Update()
-
 		assert.Equal(t, c.expectedRes, joinParams(c.params, c.defaultParams))
 	}
 }

--- a/pkg/service/manipulator_test.go
+++ b/pkg/service/manipulator_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func TestNewManipulator(t *testing.T) {
-	m := NewManipulator(native.NewBildProcessor(), map[string]string{})
+	m := NewManipulator(native.NewBildProcessor(), nil)
 	assert.NotNil(t, m)
 }
 
@@ -23,7 +23,7 @@ func TestNewManipulator(t *testing.T) {
 func TestManipulator_Process_ReturnsImageAsPNGIfCallerDoesNOTSupportWebP(t *testing.T) {
 	// Use real processor to ensure that right encoder is being used
 	p := native.NewBildProcessor()
-	m := NewManipulator(p, map[string]string{})
+	m := NewManipulator(p, nil)
 
 	img, _ := ioutil.ReadFile("../processor/native/_testdata/test.webp")
 	expectedImg, _ := ioutil.ReadFile("../processor/native/_testdata/test_webp_to_png.png")
@@ -41,7 +41,7 @@ func TestManipulator_Process_ReturnsImageAsPNGIfCallerDoesNOTSupportWebP(t *test
 func TestManipulator_Process_ReturnsImageAsWebPIfCallerSupportsWebP(t *testing.T) {
 	// Use real processor to ensure that right encoder is being used
 	p := native.NewBildProcessor()
-	m := NewManipulator(p, map[string]string{})
+	m := NewManipulator(p, nil)
 
 	img, _ := ioutil.ReadFile("../processor/native/_testdata/test.png")
 	expectedImg, _ := ioutil.ReadFile("../processor/native/_testdata/test_png_to_webp.webp")
@@ -58,7 +58,7 @@ func TestManipulator_Process_ReturnsImageAsWebPIfCallerSupportsWebP(t *testing.T
 
 func TestManipulator_Process(t *testing.T) {
 	mp := &mockProcessor{}
-	m := NewManipulator(mp, map[string]string{})
+	m := NewManipulator(mp, nil)
 	params := make(map[string]string)
 
 	input := []byte("inputData")
@@ -71,7 +71,7 @@ func TestManipulator_Process(t *testing.T) {
 
 	// Create new struct for asserting expectations
 	mp = &mockProcessor{}
-	m = NewManipulator(mp, map[string]string{})
+	m = NewManipulator(mp, nil)
 	mp.On("Decode", input).Return(decoded, "png", nil)
 	mp.On("Encode", decoded, "png").Return(input, nil)
 	mp.On("Crop", decoded, 100, 100, processor.CropCenter).Return(decoded, nil)
@@ -129,7 +129,7 @@ func TestGetParams(t *testing.T) {
 			expectedRes:   map[string]string{"foo": "bar", "bar": "foo"},
 		},
 		{
-			params:        map[string]string{},
+			params:        nil,
 			defaultParams: map[string]string{"bar": "foo"},
 			expectedRes:   map[string]string{"bar": "foo"},
 		},
@@ -140,7 +140,7 @@ func TestGetParams(t *testing.T) {
 		},
 		{
 			params:        map[string]string{"foo": "bar"},
-			defaultParams: map[string]string{},
+			defaultParams: nil,
 			expectedRes:   map[string]string{"foo": "bar"},
 		},
 	}


### PR DESCRIPTION
---
name: Default Parameters Support
about: Adding support for having a default parameters which will always by applied without being passed by the caller
labels: enhancement

---

##### What would you like to be added
Apply default parameters on all download requests based on environment configuration.

##### Why is this needed
Imgix has it and on some of our Imgix sources, we set `auto=compress` to be always applied by default on some buckets.

##### Comments
- Ref: https://blog.imgix.com/2017/01/24/default-parameters