### PR TITLE
Resize the image in case of cropping request does NOT pass one of w/h

### DIFF
--- a/pkg/processor/native/processor.go
+++ b/pkg/processor/native/processor.go
@@ -28,6 +28,13 @@ type ProcessorOption func(*BildProcessor)
 
 // Crop takes an input image, width, height and a CropPoint and returns the cropped image
 func (bp *BildProcessor) Crop(img image.Image, width, height int, point processor.CropPoint) image.Image {
+	if width == 0 || height == 0 {
+		if width == 0 && height == 0 {
+			return img
+		}
+		return bp.Resize(img, width, height)
+	}
+
 	w, h := getResizeWidthAndHeightForCrop(width, height, img.Bounds().Dx(), img.Bounds().Dy())
 	img = transform.Resize(img, w, h, transform.Linear)
 	x0, y0 := getStartingPointForCrop(w, h, width, height, point)

--- a/pkg/processor/native/processor_test.go
+++ b/pkg/processor/native/processor_test.go
@@ -51,12 +51,45 @@ func (s *BildProcessorSuite) TestBildProcessor_ResizeWithSameWidthAndHeight() {
 }
 
 func (s *BildProcessorSuite) TestBildProcessor_Crop() {
-	out := s.processor.Crop(s.srcImage, 500, 500, processor.CropCenter)
+	cases := []struct {
+		w         int
+		h         int
+		expectedW int
+		expectedH int
+	}{
+		{
+			w:         500,
+			h:         500,
+			expectedW: 500,
+			expectedH: 500,
+		},
+		{
+			w:         500,
+			h:         0,
+			expectedW: 500,
+			expectedH: 375,
+		},
+		{
+			w:         0,
+			h:         500,
+			expectedW: 666,
+			expectedH: 500,
+		},
+		{
+			w:         0,
+			h:         0,
+			expectedW: 500,
+			expectedH: 375,
+		},
+	}
+	for _, c := range cases {
+		out := s.processor.Crop(s.srcImage, c.w, c.h, processor.CropCenter)
 
-	assert.NotNil(s.T(), out)
+		assert.NotNil(s.T(), out)
 
-	assert.Equal(s.T(), 500, out.Bounds().Dx())
-	assert.Equal(s.T(), 500, out.Bounds().Dy())
+		assert.Equal(s.T(), c.expectedW, out.Bounds().Dx())
+		assert.Equal(s.T(), c.expectedH, out.Bounds().Dy())
+	}
 }
 
 func (s *BildProcessorSuite) TestBildProcessor_Grayscale() {


### PR DESCRIPTION
---
name: Feature Request
about: Suggest a/an feature/enhancement to the Darkroom project
labels: enhancement

---

##### What would you like to be added

Darkroom to return resized image in case of one of w or h is not being provided by the caller. If both of them are missing, return the original image.

##### Why is this needed

The old contract we wanted to keep is to not return blank RGBA image in case above request appears.

##### Comments

Link to issue: https://github.com/gojek/darkroom/issues/37