### PR TITLE
Rearranged cache headers

### DIFF
--- a/internal/handler/image.go
+++ b/internal/handler/image.go
@@ -55,10 +55,11 @@ func ImageHandler(deps *service.Dependencies) http.HandlerFunc {
 			}
 		}
 
-		cl, _ := w.Write(data)
-		w.Header().Set(ContentLengthHeader, fmt.Sprintf("%d", cl))
 		w.Header().Set(CacheControlHeader, fmt.Sprintf("public,max-age=%d", config.CacheTime()))
 		// Ref to Google CDN we support: https://cloud.google.com/cdn/docs/caching#cacheability
 		w.Header().Set(VaryHeader, "Accept")
+		
+		cl, _ := w.Write(data)
+		w.Header().Set(ContentLengthHeader, fmt.Sprintf("%d", cl))
 	}
 }


### PR DESCRIPTION
Cache headers are not set predictably. The cache headers are not being returned when deployed on an EC2.

https://stackoverflow.com/questions/43202919/http-headers-not-returned-on-ec2