### PR TITLE
Fixed the behavior of default params if they are present

### DIFF
--- a/internal/handler/image.go
+++ b/internal/handler/image.go
@@ -40,7 +40,7 @@ func ImageHandler(deps *service.Dependencies) http.HandlerFunc {
 
 		params := make(map[string]string)
 		values := r.URL.Query()
-		if len(values) > 0 || len(deps.DefaultParams) > 0 {
+		if len(values) > 0 || deps.Manipulator.HasDefaultParams() {
 			for v := range values {
 				if len(values.Get(v)) != 0 {
 					params[v] = values.Get(v)

--- a/internal/handler/image.go
+++ b/internal/handler/image.go
@@ -40,7 +40,7 @@ func ImageHandler(deps *service.Dependencies) http.HandlerFunc {
 
 		params := make(map[string]string)
 		values := r.URL.Query()
-		if len(values) > 0 {
+		if len(values) > 0 || len(deps.DefaultParams) > 0 {
 			for v := range values {
 				if len(values.Get(v)) != 0 {
 					params[v] = values.Get(v)
@@ -58,7 +58,7 @@ func ImageHandler(deps *service.Dependencies) http.HandlerFunc {
 		w.Header().Set(CacheControlHeader, fmt.Sprintf("public,max-age=%d", config.CacheTime()))
 		// Ref to Google CDN we support: https://cloud.google.com/cdn/docs/caching#cacheability
 		w.Header().Set(VaryHeader, "Accept")
-		
+
 		cl, _ := w.Write(data)
 		w.Header().Set(ContentLengthHeader, fmt.Sprintf("%d", cl))
 	}

--- a/internal/handler/image_test.go
+++ b/internal/handler/image_test.go
@@ -4,11 +4,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/gojek/darkroom/pkg/metrics"
 	"net/http"
 	"net/http/httptest"
 	"testing"
-
-	"github.com/gojek/darkroom/pkg/metrics"
 
 	"github.com/gojek/darkroom/pkg/config"
 	"github.com/gojek/darkroom/pkg/service"

--- a/internal/handler/image_test.go
+++ b/internal/handler/image_test.go
@@ -39,13 +39,13 @@ func (s *ImageHandlerTestSuite) SetupTest() {
 }
 
 func (s *ImageHandlerTestSuite) TestImageHandlerWithoutDefaultParams() {
-	s.deps.DefaultParams = make(map[string]string)
-
 	r, _ := http.NewRequest(http.MethodGet, "/image-valid", nil)
 	rr := httptest.NewRecorder()
 	data := []byte("validData")
 
 	s.storage.On("Get", mock.Anything, "/image-valid").Return(data, http.StatusOK, nil)
+	s.manipulator.On("HasDefaultParams").Return(false)
+
 	ImageHandler(s.deps).ServeHTTP(rr, r)
 
 	assert.Equal(s.T(), "validData", rr.Body.String())
@@ -53,15 +53,12 @@ func (s *ImageHandlerTestSuite) TestImageHandlerWithoutDefaultParams() {
 }
 
 func (s *ImageHandlerTestSuite) TestImageHandlerWithDefaultParams() {
-	s.deps.DefaultParams = map[string]string{
-		"auto": "compress",
-	}
-
 	r, _ := http.NewRequest(http.MethodGet, "/image-valid", nil)
 	rr := httptest.NewRecorder()
 	data := []byte("validData")
 
 	s.storage.On("Get", mock.Anything, "/image-valid").Return(data, http.StatusOK, nil)
+	s.manipulator.On("HasDefaultParams").Return(true)
 	s.manipulator.On("Process", mock.AnythingOfType("service.processSpec")).Return(data, nil)
 
 	ImageHandler(s.deps).ServeHTTP(rr, r)

--- a/pkg/service/dependencies.go
+++ b/pkg/service/dependencies.go
@@ -41,9 +41,8 @@ func NewDependencies(registry *prometheus.Registry) (*Dependencies, error) {
 		metricService = metrics.NoOpMetricService{}
 		logger.Warn("NoOpMetricService is being used since metric system is not specified")
 	}
-	defaultParams := getDefaultParams()
 	deps := &Dependencies{
-		Manipulator:   NewManipulator(native.NewBildProcessor(), defaultParams, metricService),
+		Manipulator:   NewManipulator(native.NewBildProcessor(), getDefaultParams(), metricService),
 		MetricService: metricService,
 	}
 

--- a/pkg/service/dependencies.go
+++ b/pkg/service/dependencies.go
@@ -3,13 +3,13 @@ package service
 
 import (
 	"errors"
-	"strings"
-	"time"
 
 	"github.com/gojek/darkroom/pkg/logger"
 	"github.com/gojek/darkroom/pkg/metrics"
 	"github.com/gojek/darkroom/pkg/regex"
 	"github.com/prometheus/client_golang/prometheus"
+	"strings"
+	"time"
 
 	"github.com/gojek/darkroom/pkg/config"
 	"github.com/gojek/darkroom/pkg/processor/native"

--- a/pkg/service/dependencies.go
+++ b/pkg/service/dependencies.go
@@ -26,7 +26,6 @@ type Dependencies struct {
 	Storage       base.Storage
 	Manipulator   Manipulator
 	MetricService metrics.MetricService
-	DefaultParams map[string]string
 }
 
 // NewDependencies constructs new Dependencies based on the config.DataSource().Kind
@@ -46,7 +45,6 @@ func NewDependencies(registry *prometheus.Registry) (*Dependencies, error) {
 	deps := &Dependencies{
 		Manipulator:   NewManipulator(native.NewBildProcessor(), defaultParams, metricService),
 		MetricService: metricService,
-		DefaultParams: defaultParams,
 	}
 
 	s := config.DataSource()

--- a/pkg/service/manipulator.go
+++ b/pkg/service/manipulator.go
@@ -45,7 +45,7 @@ type Manipulator interface {
 	// Process takes ProcessSpec as an argument and returns []byte, error
 	Process(spec processSpec) ([]byte, error)
 
-	// Whether or not default params are present
+	// HasDefaultParams returns true if defaultParams are present, returns false otherwise
 	HasDefaultParams() bool
 }
 
@@ -129,7 +129,7 @@ func (m *manipulator) Process(spec processSpec) ([]byte, error) {
 	return src, err
 }
 
-// This function returns true if defaultParams are present, returns false otherwise
+// HasDefaultParams returns true if defaultParams are present, returns false otherwise
 func (m *manipulator) HasDefaultParams() bool {
 	return len(m.defaultParams) > 0
 }

--- a/pkg/service/manipulator.go
+++ b/pkg/service/manipulator.go
@@ -44,6 +44,9 @@ const (
 type Manipulator interface {
 	// Process takes ProcessSpec as an argument and returns []byte, error
 	Process(spec processSpec) ([]byte, error)
+
+	// Whether or not default params are present
+	HasDefaultParams() bool
 }
 
 type manipulator struct {
@@ -124,6 +127,11 @@ func (m *manipulator) Process(spec processSpec) ([]byte, error) {
 		m.metricService.TrackDuration(encodeDurationKey, t, spec.ImageData)
 	}
 	return src, err
+}
+
+// This function returns true if defaultParams are present, returns false otherwise
+func (m *manipulator) HasDefaultParams() bool {
+	return len(m.defaultParams) > 0
 }
 
 func joinParams(params map[string]string, defaultParams map[string]string) map[string]string {

--- a/pkg/service/manipulator_test.go
+++ b/pkg/service/manipulator_test.go
@@ -2,15 +2,16 @@ package service
 
 import (
 	"errors"
+	"image"
+	"io/ioutil"
+	"testing"
+
 	"github.com/gojek/darkroom/pkg/metrics"
 	"github.com/gojek/darkroom/pkg/processor"
 	"github.com/gojek/darkroom/pkg/processor/native"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
-	"image"
-	"io/ioutil"
-	"testing"
 )
 
 func TestNewManipulator(t *testing.T) {
@@ -179,6 +180,14 @@ func TestCleanInt(t *testing.T) {
 	assert.Equal(t, 0, CleanInt("0"))
 	assert.Equal(t, 0, CleanInt("garbage"))
 	assert.Equal(t, 0, CleanInt("-234"))
+}
+
+func TestManipulator_HasDefaultParams(t *testing.T) {
+	manipulatorWithDefaultParams := NewManipulator(nil, map[string]string{"auto": "compress"}, nil)
+	manipulatorWithoutDefaultParams := NewManipulator(nil, map[string]string{}, nil)
+
+	assert.Equal(t, true, manipulatorWithDefaultParams.HasDefaultParams())
+	assert.Equal(t, false, manipulatorWithoutDefaultParams.HasDefaultParams())
 }
 
 type mockProcessor struct {

--- a/pkg/service/manipulator_test.go
+++ b/pkg/service/manipulator_test.go
@@ -2,9 +2,6 @@ package service
 
 import (
 	"errors"
-	"image"
-	"io/ioutil"
-	"testing"
 
 	"github.com/gojek/darkroom/pkg/metrics"
 	"github.com/gojek/darkroom/pkg/processor"
@@ -12,6 +9,9 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"image"
+	"io/ioutil"
+	"testing"
 )
 
 func TestNewManipulator(t *testing.T) {

--- a/pkg/service/mock.go
+++ b/pkg/service/mock.go
@@ -12,3 +12,8 @@ func (m *MockManipulator) Process(spec processSpec) ([]byte, error) {
 	args := m.Called(spec)
 	return args.Get(0).([]byte), args.Error(1)
 }
+
+func (m *MockManipulator) HasDefaultParams() bool {
+	args := m.Called()
+	return args.Get(0).(bool)
+}


### PR DESCRIPTION
Currently the default params config is completely ignored if there are no arguments present in the query string. Ideally, the manipulator should kick in if there is a `defaultParam` configuration present.