### PR TITLE
feat: add Credentials as options on Google Cloud Storage package

### DIFF
--- a/pkg/storage/gcs/hystrix.go
+++ b/pkg/storage/gcs/hystrix.go
@@ -2,6 +2,7 @@ package gcs
 
 import (
 	"context"
+	"golang.org/x/oauth2/google"
 	"net/http"
 
 	"cloud.google.com/go/storage"
@@ -14,8 +15,8 @@ import (
 
 const userAgent = "gcloud-golang-storage/20151204"
 
-func newHeimdallHTTPClient(ctx context.Context, hc heimdall.Client, credentialsJSON []byte) (*http.Client, error) {
-	t, err := newTransport(ctx, hc, credentialsJSON)
+func newHeimdallHTTPClient(ctx context.Context, opts *Options) (*http.Client, error) {
+	t, err := newTransport(ctx, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -24,16 +25,24 @@ func newHeimdallHTTPClient(ctx context.Context, hc heimdall.Client, credentialsJ
 	}, nil
 }
 
-func newTransport(ctx context.Context, hc heimdall.Client, credentialsJSON []byte) (http.RoundTripper, error) {
+func newTransport(ctx context.Context, opts *Options) (http.RoundTripper, error) {
 	o := option.WithoutAuthentication()
-	if len(credentialsJSON) > 0 {
-		o = option.WithCredentialsJSON(credentialsJSON)
+	if opts.UseDefaultCredential {
+		credential, err := google.FindDefaultCredentials(ctx)
+		if err != nil {
+			return nil, err
+		}
+		o = option.WithCredentials(credential)
+	} else if len(opts.CredentialsJSON) > 0 {
+		o = option.WithCredentialsJSON(opts.CredentialsJSON)
 	}
 	return gcloud.NewTransport(ctx,
-		&hystrixTransport{client: hc},
+		&hystrixTransport{client: opts.Client},
 		option.WithUserAgent(userAgent),
 		option.WithScopes(storage.ScopeReadOnly),
-		o)
+		o,
+	)
+
 }
 
 type hystrixTransport struct {

--- a/pkg/storage/gcs/hystrix_test.go
+++ b/pkg/storage/gcs/hystrix_test.go
@@ -2,6 +2,7 @@ package gcs
 
 import (
 	"context"
+	"golang.org/x/oauth2/google"
 	"net/http"
 	"testing"
 
@@ -23,6 +24,20 @@ func TestNewHeimdallHTTPClientWithNoCredentials(t *testing.T) {
 	hc := hystrix.NewClient()
 	hhc, err := newHeimdallHTTPClient(context.TODO(), &Options{
 		CredentialsJSON: []byte(""),
+		Client:          hc,
+	})
+	assert.NotNil(t, hhc)
+	assert.NoError(t, err)
+	req, _ := http.NewRequest(http.MethodGet, "", nil)
+	_, err = hhc.Do(req)
+	assert.Error(t, err, "expecting unsupported protocol error")
+}
+
+func TestNewHeimdallHTTPClientWithCustomCredentials(t *testing.T) {
+	hc := hystrix.NewClient()
+	hhc, err := newHeimdallHTTPClient(context.TODO(), &Options{
+		CredentialsJSON: nil,
+		Credentials:     &google.Credentials{ProjectID: "sample"},
 		Client:          hc,
 	})
 	assert.NotNil(t, hhc)

--- a/pkg/storage/gcs/hystrix_test.go
+++ b/pkg/storage/gcs/hystrix_test.go
@@ -11,14 +11,20 @@ import (
 
 func TestNewHeimdallHTTPClientWithInvalidCredentials(t *testing.T) {
 	hc := hystrix.NewClient()
-	hhc, err := newHeimdallHTTPClient(context.TODO(), hc, []byte("random"))
+	hhc, err := newHeimdallHTTPClient(context.TODO(), &Options{
+		CredentialsJSON: []byte("random"),
+		Client:          hc,
+	})
 	assert.Nil(t, hhc)
 	assert.Error(t, err)
 }
 
 func TestNewHeimdallHTTPClientWithNoCredentials(t *testing.T) {
 	hc := hystrix.NewClient()
-	hhc, err := newHeimdallHTTPClient(context.TODO(), hc, []byte(""))
+	hhc, err := newHeimdallHTTPClient(context.TODO(), &Options{
+		CredentialsJSON: []byte(""),
+		Client:          hc,
+	})
 	assert.NotNil(t, hhc)
 	assert.NoError(t, err)
 	req, _ := http.NewRequest(http.MethodGet, "", nil)

--- a/pkg/storage/gcs/options.go
+++ b/pkg/storage/gcs/options.go
@@ -8,6 +8,8 @@ type Options struct {
 	BucketName string
 	// CredentialsJSON holds the json data for credentials of a service account
 	CredentialsJSON []byte
+	// UseDefaultCredential toggle the usage of google application default credential to authenticate with cloud storage
+	UseDefaultCredential bool
 	// Client can be used to specify a heimdall.Client with hystrix like circuit breaker
 	Client heimdall.Client
 }

--- a/pkg/storage/gcs/options.go
+++ b/pkg/storage/gcs/options.go
@@ -1,6 +1,9 @@
 package gcs
 
-import "github.com/gojektech/heimdall"
+import (
+	"github.com/gojektech/heimdall"
+	"golang.org/x/oauth2/google"
+)
 
 // Options represents the Google Cloud Storage storage options
 type Options struct {
@@ -8,8 +11,8 @@ type Options struct {
 	BucketName string
 	// CredentialsJSON holds the json data for credentials of a service account
 	CredentialsJSON []byte
-	// UseDefaultCredential toggle the usage of google application default credential to authenticate with cloud storage
-	UseDefaultCredential bool
+	// Credentials represents google credentials, including Application Default Credentials
+	Credentials *google.Credentials
 	// Client can be used to specify a heimdall.Client with hystrix like circuit breaker
 	Client heimdall.Client
 }

--- a/pkg/storage/gcs/storage.go
+++ b/pkg/storage/gcs/storage.go
@@ -32,7 +32,7 @@ type Storage struct {
 // NewStorage returns a new gcs.Storage instance
 func NewStorage(opts Options) (*Storage, error) {
 	ctx := context.TODO()
-	client, err := newHeimdallHTTPClient(ctx, opts.Client, opts.CredentialsJSON)
+	client, err := newHeimdallHTTPClient(ctx, &opts)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Enable users to use Google ADC(Application Default Credentials) to authenticate with Google Cloud Storage.